### PR TITLE
Restore banning functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "juliet"
 version = "0.2.1"
-source = "git+https://github.com/casper-network/juliet?rev=9023597835fccf85300ae794278db833f0956ca5#9023597835fccf85300ae794278db833f0956ca5"
+source = "git+https://github.com/casper-network/juliet?rev=529f17c097c79b87c1d241514becd72c73f93fef#529f17c097c79b87c1d241514becd72c73f93fef"
 dependencies = [
  "array-init",
  "bimap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "juliet"
 version = "0.2.1"
-source = "git+https://github.com/casper-network/juliet?rev=67ff4778c670bf96ebf86fa28575e708b9997765#67ff4778c670bf96ebf86fa28575e708b9997765"
+source = "git+https://github.com/casper-network/juliet?rev=9023597835fccf85300ae794278db833f0956ca5#9023597835fccf85300ae794278db833f0956ca5"
 dependencies = [
  "array-init",
  "bimap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "juliet"
 version = "0.2.1"
-source = "git+https://github.com/casper-network/juliet?rev=529f17c097c79b87c1d241514becd72c73f93fef#529f17c097c79b87c1d241514becd72c73f93fef"
+source = "git+https://github.com/casper-network/juliet?rev=90f92f08b8bf803089b5ae147c0072a02d8f4dd0#90f92f08b8bf803089b5ae147c0072a02d8f4dd0"
 dependencies = [
  "array-init",
  "bimap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -41,7 +41,7 @@ http = "0.2.1"
 humantime = "2.1.0"
 hyper = "0.14.26"
 itertools = "0.10.0"
-juliet = { git = "https://github.com/casper-network/juliet", rev = "67ff4778c670bf96ebf86fa28575e708b9997765", features = ["tracing"] }
+juliet = { git = "https://github.com/casper-network/juliet", rev = "9023597835fccf85300ae794278db833f0956ca5", features = ["tracing"] }
 libc = "0.2.66"
 linked-hash-map = "0.5.3"
 lmdb-rkv = "0.14"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -41,7 +41,7 @@ http = "0.2.1"
 humantime = "2.1.0"
 hyper = "0.14.26"
 itertools = "0.10.0"
-juliet = { git = "https://github.com/casper-network/juliet", rev = "9023597835fccf85300ae794278db833f0956ca5", features = ["tracing"] }
+juliet = { git = "https://github.com/casper-network/juliet", rev = "529f17c097c79b87c1d241514becd72c73f93fef", features = ["tracing"] }
 libc = "0.2.66"
 linked-hash-map = "0.5.3"
 lmdb-rkv = "0.14"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -41,7 +41,7 @@ http = "0.2.1"
 humantime = "2.1.0"
 hyper = "0.14.26"
 itertools = "0.10.0"
-juliet = { git = "https://github.com/casper-network/juliet", rev = "529f17c097c79b87c1d241514becd72c73f93fef", features = ["tracing"] }
+juliet = { git = "https://github.com/casper-network/juliet", rev = "90f92f08b8bf803089b5ae147c0072a02d8f4dd0", features = ["tracing"] }
 libc = "0.2.66"
 linked-hash-map = "0.5.3"
 lmdb-rkv = "0.14"

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -905,7 +905,7 @@ where
                                     self.config.blocklist_retain_duration.millis(),
                                 );
 
-                            conman.ban_peer(*offender, *justification, until);
+                            conman.ban_peer(*offender, *justification, now, until);
                         } else {
                             error!("cannot ban, component not initialized");
                         };

--- a/node/src/components/network/conman.rs
+++ b/node/src/components/network/conman.rs
@@ -592,8 +592,12 @@ async fn handle_incoming(
                 |dropped| info!(until=?entry.until, justification=%entry.justification, dropped, "peer is still banned")
             );
 
-            // TODO: Send a proper error using RPC client/server here (requires appropriate
-            //       Juliet API). This would allow the peer to update its backoff timer.
+            tokio::spawn(rpc_server.send_custom_error_and_shutdown(
+                ChannelId::new(0),
+                Id::new(0),
+                Bytes::from(&b"you are still banned"[..]),
+            ));
+
             return;
         }
 

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -302,7 +302,6 @@ fn network_is_complete(
 
     for (node_id, node) in nodes {
         let net = &node.reactor().inner().net;
-        // TODO: Ensure the connections are symmetrical.
         let peers: HashSet<_> = net.peers().into_keys().collect();
 
         let mut missing = expected.difference(&peers);


### PR DESCRIPTION
The required functionality in `juliet` has been added straight to the `main` branch there:

https://github.com/casper-network/juliet/commit/9023597835fccf85300ae794278db833f0956ca5
https://github.com/casper-network/juliet/commit/529f17c097c79b87c1d241514becd72c73f93fef
https://github.com/casper-network/juliet/commit/90f92f08b8bf803089b5ae147c0072a02d8f4dd0

Juliet will make a better effort to actually send error messages and ensure connections are terminated once an error has been injected locally. Conman makes use of this by terminating connections upon ban through injection of a custom error that also gives details about bans.